### PR TITLE
Add `.separator()` and `.is-separator-invalid()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 [//]: # (>>   The order of list items should be: Critical/Fixes, New, Update, Remove, Underpinnings   <<)
 [//]: # (>>   ## [UNRELEASED]https://github.com/roydukkey/sass-module-exception/compare/v1.0.0...master   <<)
 
+## [UNRELEASED](https://github.com/roydukkey/sass-module-exception/compare/v1.0.0...master)
+
+* Add `.is-separator-invalid()`
+* Add `.separator()`
+* Remove `.github` and `.vscode` folders from package
+
 ## 1.0.0
 
 * Initial release!

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ sass.render({
   <dt><a href="//github.com/roydukkey/sass-module-exception/tree/master/src/exception/_parameter-type.sass"><code>parameter-type ( $context, $name, $value, $types... )</code></a></dt>
   <dd>Returns an error message stating a parameter received the wrong type.</dd>
 
+  <dt><a href="//github.com/roydukkey/sass-module-exception/tree/master/src/exception/_separator.sass"><code>separator ( [$context] )</code></a></dt>
+  <dd>Returns an error message stating a separator parameter or variable received the wrong value.</dd>
+
   <dt><a href="//github.com/roydukkey/sass-module-exception/tree/master/src/exception/_variable.sass"><code>variable ( $message, $names... )</code></a></dt>
   <dd>Returns an error message stating an issue with one or more variables.</dd>
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ sass.render({
 
 <dl>
 
+  <dt><a href="//github.com/roydukkey/sass-module-exception/tree/master/src/exception/_is-separator-invalid.sass"><code>is-separator-invalid ( $value )</code></a></dt>
+  <dd>Indicates whether a specified value is invalid for a separator parameter.</dd>
+
   <dt><a href="//github.com/roydukkey/sass-module-exception/tree/master/src/exception/_parameter.sass"><code>parameter ( $message, $context, $names... )</code></a></dt>
   <dd>Returns an error message stating an issue with one or more parameters.</dd>
 

--- a/src/exception/_is-separator-invalid.sass
+++ b/src/exception/_is-separator-invalid.sass
@@ -1,0 +1,18 @@
+// Copyright (c) roydukkey. All rights reserved.
+// Licensed under the MIT. See LICENSE file in the project root for full license information.
+////
+/// @author roydukkey
+/// @group api
+////
+
+
+///
+/// Indicates whether a specified value is invalid for a separator parameter.
+///
+///	@param {*} $value - The value which is being validated.
+/// @return {Boolean}
+///
+/// @access public
+///
+@function is-separator-invalid($value)
+	@return $value != space and $value != comma and $value != slash and $value != auto

--- a/src/exception/_separator.sass
+++ b/src/exception/_separator.sass
@@ -1,0 +1,32 @@
+// Copyright (c) roydukkey. All rights reserved.
+// Licensed under the MIT. See LICENSE file in the project root for full license information.
+////
+/// @author roydukkey
+/// @group api
+////
+
+@use 'parameter'
+@use 'variable'
+
+
+///
+/// Returns an error message stating a separator variable received the wrong value.
+///
+	@overload separator()
+///
+/// Returns an error message stating a separator parameter received the wrong value.
+///
+/// @param {String} $context - The name of the function or mixin issuing the error.
+///
+	@overload separator($context)
+///
+/// @return {String}
+///
+/// @access public
+/// @require parameter.parameter
+/// @require variable.variable
+///
+@function separator($context: null)
+	$message: 'Must be "space", "comma", "slash", or "auto"'
+	$name: 'separator'
+	@return if($context == null, variable.variable($message, $name), parameter.parameter($message, $context, $name))

--- a/src/index.sass
+++ b/src/index.sass
@@ -8,6 +8,7 @@
 // In order to avoid circular dependencies, no deeper indexes should not exist.
 //
 
+@forward 'exception/is-separator-invalid'
 @forward 'exception/parameter'
 @forward 'exception/parameter-type'
 @forward 'exception/variable'

--- a/src/index.sass
+++ b/src/index.sass
@@ -11,5 +11,6 @@
 @forward 'exception/is-separator-invalid'
 @forward 'exception/parameter'
 @forward 'exception/parameter-type'
+@forward 'exception/separator'
 @forward 'exception/variable'
 @forward 'exception/variable-type'

--- a/test/exception/_is-separator-invalid.sass
+++ b/test/exception/_is-separator-invalid.sass
@@ -1,0 +1,41 @@
+// Copyright (c) roydukkey. All rights reserved.
+// Licensed under the MIT. See LICENSE file in the project root for full license information.
+////
+/// @author roydukkey
+/// @group tests
+////
+
+@use 'src'
+@use 'true'
+
+
+@include true.describe('@function src.is-separator-invalid')
+
+	@include true.it('Indicates the value is invalid')
+		$assert: src.is-separator-invalid('a')
+		@include true.assert-true($assert, '[a]')
+
+		$assert: src.is-separator-invalid(100)
+		@include true.assert-true($assert, '[100]')
+
+		$assert: src.is-separator-invalid(true)
+		@include true.assert-true($assert, '[true]')
+
+		$assert: src.is-separator-invalid(false)
+		@include true.assert-true($assert, '[true]')
+
+		$assert: src.is-separator-invalid(null)
+		@include true.assert-true($assert, '[null]')
+
+	@include true.it('Indicates the value is valid')
+		$assert: src.is-separator-invalid(space)
+		@include true.assert-false($assert, '[space]')
+
+		$assert: src.is-separator-invalid(comma)
+		@include true.assert-false($assert, '[comma]')
+
+		$assert: src.is-separator-invalid('slash')
+		@include true.assert-false($assert, '[slash]')
+
+		$assert: src.is-separator-invalid('auto')
+		@include true.assert-false($assert, '[auto]')

--- a/test/exception/_separator.sass
+++ b/test/exception/_separator.sass
@@ -1,0 +1,22 @@
+// Copyright (c) roydukkey. All rights reserved.
+// Licensed under the MIT. See LICENSE file in the project root for full license information.
+////
+/// @author roydukkey
+/// @group tests
+////
+
+@use 'src'
+@use 'true'
+
+
+@include true.describe('@function src.separator')
+
+	@include true.it('Formats an error message for variable')
+		$assert: src.separator()
+		$expected: '$separator: Must be "space", "comma", "slash", or "auto".'
+		@include true.assert-equal($assert, $expected)
+
+	@include true.it('Formats an error message for parameter')
+		$assert: src.separator('append')
+		$expected: '$separator: Must be "space", "comma", "slash", or "auto" for `append()`.'
+		@include true.assert-equal($assert, $expected)

--- a/test/index.sass
+++ b/test/index.sass
@@ -20,4 +20,5 @@
 @use 'exception/parameter'
 @use 'exception/is-separator-invalid'
 @use 'exception/parameter-type'
+@use 'exception/separator'
 @use 'exception/variable-type'

--- a/test/index.sass
+++ b/test/index.sass
@@ -18,5 +18,6 @@
 @use 'exception/variable'
 // Required by 'src/exception/parameter-type'
 @use 'exception/parameter'
+@use 'exception/is-separator-invalid'
 @use 'exception/parameter-type'
 @use 'exception/variable-type'


### PR DESCRIPTION
Closes #1